### PR TITLE
🔩Code: Max. image allocation size increased to 4 GB.

### DIFF
--- a/src/ui/ImageAreaWidget.cpp
+++ b/src/ui/ImageAreaWidget.cpp
@@ -27,8 +27,6 @@ along with this program.If not, see <http://www.gnu.org/licenses/>.
 #include <QPainter>
 #include <cmath>
 
-const int ImageAreaWidget::m_imageOffsetStep = 100;
-
 ImageAreaWidget::ImageAreaWidget(QWidget *parent)
                                         : QWidget(parent)
                                         , m_drawBorder(false)
@@ -66,6 +64,7 @@ void ImageAreaWidget::drawBorder(const bool draw, const QColor &color)
 bool ImageAreaWidget::showImage(const QString &fileName)
 {
     m_animationTimer.stop();
+    m_reader.setAllocationLimit(ImageAreaWidget::m_maxAllocationImageSize);
     m_reader.setFileName(fileName);
     m_reader.setQuality(100);
     m_reader.setAutoTransform(true);

--- a/src/ui/ImageAreaWidget.h
+++ b/src/ui/ImageAreaWidget.h
@@ -95,5 +95,6 @@ private:
     QTimer m_animationTimer;
     RotatingIndex<int> m_animationIndex;
 
-    static const int m_imageOffsetStep;
+    static constexpr int m_imageOffsetStep = 100;
+    static constexpr int m_maxAllocationImageSize = 4096;
 };


### PR DESCRIPTION
RAW images needs more memory than the default 128MB.