### PR TITLE
Wix 4 & 5 support

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -88,6 +88,16 @@ jobs:
         $name = Get-Childitem -Filter *.msi -Name
         echo "artifact_name_msi=$name" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+    - name: archive log [msi]
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: wix_msi_log.zip
+        path: |
+          D:/a/vooki-image-viewer/build/_CPack_Packages/win64/WIX/wix.log
+        if-no-files-found: ignore
+        retention-days: 9
+
     - name: archive artifacts [zip]
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -37,10 +37,14 @@ jobs:
         arch: ${{ env.MINGW_VERSION }}
         dir: "${{github.workspace}}/qt"
         install-deps: "true"
-
     -
       name: install graphviz
       run: choco install graphviz
+    - name: update WiX
+      run: |
+        dotnet tool update --global wix
+        wix --version
+        wix extension add --global WixToolset.UI.wixext
     -
       name: build 3rd-party sources [configuration]
       working-directory: ${{github.workspace}}\..

--- a/build/cmake/platform/windows/CPack.cmake
+++ b/build/cmake/platform/windows/CPack.cmake
@@ -41,6 +41,7 @@ foreach(GENERATOR IN LISTS CPACK_GENERATOR)
         GET_FILENAME_COMPONENT(PACKAGE_SUPPORT_DIR "platform/Windows/support/package/" ABSOLUTE)
         GET_FILENAME_COMPONENT(PACKAGE_PRODUCT_ICON "../../src/resource/openclipart/vookiimageviewericon.ico" ABSOLUTE)
 
+        SET(CPACK_WIX_VERSION 4)
         SET(CPACK_WIX_UPGRADE_GUID "91FA8A80-C971-408A-A735-4EB3D230D9F6")
         SET(CPACK_WIX_LICENSE_RTF "${PACKAGE_SUPPORT_DIR}/gpl-3.0.rtf")
         SET(CPACK_WIX_UI_BANNER "${PACKAGE_SUPPORT_DIR}/wix-vookiimageviewer-banner.png")

--- a/build/cmake/platform/windows/generate-ep.bat
+++ b/build/cmake/platform/windows/generate-ep.bat
@@ -5,7 +5,7 @@ if "%~1"=="no-qt-override" (
   echo Don't forget to set proper Qt env. variables
 ) else (
   echo Setting the Qt env. variables
-  set "QTDIR=c:\Qt\6.4.3\msvc2019_64"
+  set "QTDIR=c:\Qt\6.8.0\msvc2022_64"
 )
 
 cmake -DBUILD_DEPENDENCIES=ON -A x64 -G "Visual Studio 17 2022" -H. -Bbuild ../../../.. -Wno-dev -DQt6_DIR="%QTDIR%\lib\cmake\Qt6" -DQt6CoreTools_DIR="%QTDIR%\lib\cmake\Qt6Core" -DQt6CoreTools_DIR="%QTDIR%\lib\cmake\Qt6CoreTools" -DQt6Gui_DIR="%QTDIR%\lib\cmake\Qt6Gui" -DQt6GuiTools_DIR="%QTDIR%\lib\cmake\Qt6GuiTools" -DQt6Widgets_DIR="%QTDIR%\lib\cmake\Qt6Widgets" -DQt6WidgetsTools_DIR="%QTDIR%\lib\cmake\Qt6WidgetsTools"

--- a/build/cmake/platform/windows/generate.bat
+++ b/build/cmake/platform/windows/generate.bat
@@ -5,7 +5,7 @@ if "%~1"=="no-qt-override" (
   echo Don't forget to set proper Qt env. variables
 ) else (
   echo Setting the Qt env. variables
-  set "QTDIR=c:\Qt\6.4.3\msvc2019_64"
+  set "QTDIR=c:\Qt\6.8.0\msvc2022_64"
 )
 
 cmake -DBUILD_DEPENDENCIES=OFF -A x64 -G "Visual Studio 17 2022" -H. -Bbuild ../../../.. -Wno-dev -DQt6_DIR="%QTDIR%\lib\cmake\Qt6" -DQt6CoreTools_DIR="%QTDIR%\lib\cmake\Qt6Core" -DQt6CoreTools_DIR="%QTDIR%\lib\cmake\Qt6CoreTools" -DQt6Gui_DIR="%QTDIR%\lib\cmake\Qt6Gui" -DQt6GuiTools_DIR="%QTDIR%\lib\cmake\Qt6GuiTools" -DQt6Widgets_DIR="%QTDIR%\lib\cmake\Qt6Widgets" -DQt6WidgetsTools_DIR="%QTDIR%\lib\cmake\Qt6WidgetsTools"

--- a/build/cmake/platform/windows/support/package/WIX.template.in
+++ b/build/cmake/platform/windows/support/package/WIX.template.in
@@ -2,17 +2,23 @@
 
 <?include "cpack_variables.wxi"?>
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" @WIX_CUSTOM_XMLNS_EXPANDED@
-    RequiredVersion="3.6.3303.0">
+<Wix
+    xmlns="http://wixtoolset.org/schemas/v4/wxs"
+    @WIX_CUSTOM_XMLNS_EXPANDED@
+    RequiredVersion="4.0"
+    >
 
-    <Product Id="$(var.CPACK_WIX_PRODUCT_GUID)"
+    <Package
         Name="$(var.CPACK_PACKAGE_NAME)"
-        Language="1033"
         Version="@VERSION_FOR_WIX@"
         Manufacturer="$(var.CPACK_PACKAGE_VENDOR)"
-        UpgradeCode="$(var.CPACK_WIX_UPGRADE_GUID)">
-
-        <Package InstallerVersion="500" Compressed="yes"/>
+        UpgradeCode="$(var.CPACK_WIX_UPGRADE_GUID)"
+        ProductCode="$(var.CPACK_WIX_PRODUCT_GUID)"
+        Scope="perMachine"
+        InstallerVersion="500"
+        Language="1033"
+        Compressed="yes"
+        >
 
         <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
@@ -22,10 +28,14 @@
             DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit."/>
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.CPACK_WIX_LICENSE_RTF)"/>
-        <Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT"/>
+
+        <ui:WixUI
+            Id="WixUI_InstallDir"
+            InstallDirectory="INSTALL_ROOT"
+        />
 
         <?ifdef CPACK_WIX_PRODUCT_ICON?>
-        <Property Id="ARPPRODUCTICON">ProductIcon.ico</Property>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon.ico" />
         <Icon Id="ProductIcon.ico" SourceFile="$(var.CPACK_WIX_PRODUCT_ICON)"/>
         <?endif?>
 
@@ -39,9 +49,7 @@
 
         <FeatureRef Id="ProductFeature"/>
 
-        <UIRef Id="$(var.CPACK_WIX_UI_REF)" />
-
         <?include "properties.wxi"?>
         <?include "product_fragment.wxi"?>
-    </Product>
+    </Package>
 </Wix>


### PR DESCRIPTION
- wix 4 & 5 was enabled in cpack.
- wix template was updated to be compatible with the wix 4/5.
- build scripts for local development were fixed (QT 6.8.0).
- tested with the wix 5.0.2+aa65968c.
